### PR TITLE
DCOS-21974: Add test to verify that the mock streams the content 

### DIFF
--- a/__tests__/helpers/requestMock.ts
+++ b/__tests__/helpers/requestMock.ts
@@ -1,0 +1,35 @@
+import { ClientRequest, request } from "http";
+import IntegrationTestEnvironment from "./integrationTestEnvironment";
+
+export enum Method {
+  GET = "GET",
+  POST = "POST"
+}
+
+export default function requestMock(
+  env: IntegrationTestEnvironment,
+  mockID: string,
+  method: Method = Method.GET,
+  body: Buffer | string | any[] = "",
+  contentType: string = "application/json"
+): ClientRequest {
+  const req = request({
+    port: env.port,
+    hostname: "localhost",
+    method,
+    headers: {
+      Cookie: `MockserverID=${mockID}`,
+      "Content-Type": contentType
+    }
+  });
+
+  if (method === "POST") {
+    const buffer = Buffer.from(body);
+
+    req.setHeader("Content-Length", Buffer.byteLength(buffer));
+    req.write(buffer);
+  }
+
+  req.end();
+  return req;
+}

--- a/__tests__/helpers/toRespondWithChunks.ts
+++ b/__tests__/helpers/toRespondWithChunks.ts
@@ -1,0 +1,53 @@
+import { ClientRequest, IncomingMessage } from "http";
+
+/**
+ * This matcher compares the received chunks with the provided ones.
+ * It wraps the provided values using `Buffer.from` so that there's no need
+ * to do so in the tests. The matcher will exit and close the connection
+ * as soon as the condition match or fail.
+ *
+ * Please note that this is an async matcher thus the tests to be async as well.
+ */
+export default function toRespondWithChunks(
+  req: ClientRequest,
+  chunks: Array<Buffer | string | any[]>
+) {
+  return new Promise((resolve, reject) => {
+    req.on("response", (response: IncomingMessage) => {
+      let i = 0;
+
+      response.on("end", () => {
+        if (i === chunks.length) {
+          resolve({
+            message: () => `expected the chunks to not match  ${chunks}`,
+            pass: true
+          });
+        }
+
+        reject({
+          message: `received ${i} of the expected ${chunks.length} chunks`,
+          pass: false
+        });
+      });
+      response.on("data", (chunk: Buffer) => {
+        const expected = Buffer.from(chunks[i++]);
+
+        if (!expected.equals(chunk)) {
+          req.abort();
+
+          reject({
+            message: `expected ${chunk} in stream to match ${expected}`,
+            pass: false
+          });
+        } else if (i === chunks.length) {
+          req.abort();
+
+          resolve({
+            message: () => `expected the chunks to not match  ${chunks}`,
+            pass: true
+          });
+        }
+      });
+    });
+  });
+}

--- a/__tests__/mock-xhr-mocks.js
+++ b/__tests__/mock-xhr-mocks.js
@@ -47,6 +47,14 @@ module.exports = {
         res.write("<mock><id>42</id></mock>");
         res.end();
       }
+    },
+    {
+      id: "stream",
+      request: (req, res) => {
+        res.write("A");
+        res.write("B");
+        res.write("C");
+      }
     }
   ]
 };

--- a/__tests__/mock-xhr-test.ts
+++ b/__tests__/mock-xhr-test.ts
@@ -1,7 +1,10 @@
+import requestMock from "./helpers/requestMock";
+
 jest.unmock("node-fetch");
 
 import fetch from "node-fetch";
 import IntegrationTestEnvironment from "./helpers/integrationTestEnvironment";
+import toRespondWithChunks from "./helpers/toRespondWithChunks";
 
 function xhr(port, options = {}) {
   return fetch(`http://localhost:${port}`, {
@@ -12,6 +15,10 @@ function xhr(port, options = {}) {
     }
   });
 }
+
+// Register `toRespondWithChunks` matcher. Please note that the current jest
+// typings are not yet supporting async matchers.
+expect.extend({ toRespondWithChunks });
 
 describe("Mock - XHR", () => {
   let env;
@@ -83,6 +90,14 @@ describe("Mock - XHR", () => {
       }).then(res => res.text());
 
       expect(response).toBe("my-binary-string");
+    });
+
+    it("streams content", async () => {
+      await expect(requestMock(env, "stream")).toRespondWithChunks([
+        "A",
+        "B",
+        "C"
+      ]);
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -211,7 +211,7 @@
       "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
       "requires": {
         "@types/connect": "3.4.32",
-        "@types/node": "10.0.3"
+        "@types/node": "10.1.4"
       }
     },
     "@types/connect": {
@@ -219,7 +219,7 @@
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
       "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
       "requires": {
-        "@types/node": "10.0.3"
+        "@types/node": "10.1.4"
       }
     },
     "@types/cookie-parser": {
@@ -257,7 +257,7 @@
       "integrity": "sha512-EehCl3tpuqiM8RUb+0255M8PhhSwTtLfmO7zBBdv0ay/VTd/zmrqDfQdZFsa5z/PVMbH2yCMZPXsnrImpATyIw==",
       "requires": {
         "@types/events": "1.2.0",
-        "@types/node": "10.0.3"
+        "@types/node": "10.1.4"
       }
     },
     "@types/glob": {
@@ -267,7 +267,7 @@
       "requires": {
         "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "10.0.3"
+        "@types/node": "10.1.4"
       }
     },
     "@types/jest": {
@@ -287,9 +287,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.3.tgz",
-      "integrity": "sha512-J7nx6JzxmtT4zyvfLipYL7jNaxvlCWpyG7JhhCQ4fQyG+AGfovAHoYR55TFx+X8akfkUJYpt5JG6GPeFMjZaCQ=="
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.4.tgz",
+      "integrity": "sha512-GpQxofkdlHYxjHad98UUdNoMO7JrmzQZoAaghtNg14Gwg7YkohcrCoJEcEMSgllx4VIZ+mYw7ZHjfaeIagP/rg=="
     },
     "@types/serve-static": {
       "version": "1.13.2",
@@ -307,7 +307,7 @@
       "dev": true,
       "requires": {
         "@types/events": "1.2.0",
-        "@types/node": "10.0.3"
+        "@types/node": "10.1.4"
       }
     },
     "JSONStream": {
@@ -1861,7 +1861,7 @@
           "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
           "dev": true,
           "requires": {
-            "@types/node": "10.0.3"
+            "@types/node": "10.1.4"
           }
         }
       }
@@ -4054,15 +4054,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -4079,22 +4077,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4225,8 +4220,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4240,7 +4234,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -4257,7 +4250,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "1.1.11"
           }
@@ -4266,15 +4258,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "5.1.1",
             "yallist": "3.0.2"
@@ -4295,7 +4285,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4384,8 +4373,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4399,7 +4387,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1.0.2"
           }
@@ -4537,7 +4524,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "@types/eventsource": "1.0.1",
     "@types/express": "4.11.1",
     "@types/jest": "22.2.3",
+    "@types/node": "10.1.4",
     "@types/ws": "5.1.0",
     "babel-jest": "23.0.1",
     "babel-preset-env": "1.7.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import cookieParser from "cookie-parser";
 import log from "npmlog";
 import { createProxyServer } from "http-proxy";
 import { IServerConfig } from "./types";
+import { AddressInfo } from "net";
 
 export interface IServerHandle {
   close: () => Promise<void>;
@@ -56,8 +57,13 @@ export default function server({
     });
 
     const listener = app.listen(port, () => {
-      // If 0 is passed as a port express searches a port for you
-      const actualPort = listener.address().port;
+      // If 0 is passed as a port express picks a random port thus we need to
+      // get the "actual" port and report it back.  Casting `address()` return
+      // to `AddressInfo` as we're not listening on a pipe or UNIX domain socket
+      // thus it always return the resp. object. For details pleas see:
+      // https://nodejs.org/docs/latest-v10.x/api/net.html#net_server_address
+      const actualPort = (listener.address() as AddressInfo).port;
+
       log.info("server", `Started mockserver on port ${actualPort}`);
       resolve({
         port: actualPort,


### PR DESCRIPTION
This PR introduces a `requestMock` helper, `toRespondWithChunks` matcher and a test to verify that the mock streams the content. 

**requestMock Helper** ( 1af299a )
This helper enables long-running (long-polling) XHR tests as it enables the test to close (abort) connections if the resp. test conditions match or fail - without this changes Jest throws warnings as there would be an async action that is still running, though the test is completed.

**toRespondWithChunks Matcher** ( f186627 )
This matcher that can be used in conjunction with the `requestMock` helper or native node `http` requests. The matcher compares the received chunks with the provided ones. It wraps the provided values using `Buffer.from` so that there's no need to do so in the tests. The matcher will exit and close the connection as soon as the condition match or fail.