### PR TITLE
DCOS-34530: json file mock

### DIFF
--- a/src/__mocks__/1-valid-json-mock.js
+++ b/src/__mocks__/1-valid-json-mock.js
@@ -1,0 +1,14 @@
+const getMockForJSON = require("../mocks").getMockForJSON;
+
+const jsonMock = {
+  ping: "pong"
+};
+
+module.exports = {
+  mocks: [
+    {
+      id: "my-json-mock",
+      request: getMockForJSON(jsonMock)
+    }
+  ]
+};

--- a/src/__tests__/mocks-test.ts
+++ b/src/__tests__/mocks-test.ts
@@ -96,7 +96,7 @@ describe("mocks", () => {
       }).not.toThrow();
     });
 
-    it("returns doesn't throw when json is provided", () => {
+    it("doesn't throw when json is provided", () => {
       const mockfilename = "1-valid-json-mock";
 
       sync.mockReturnValue([mockfilename]);

--- a/src/__tests__/mocks-test.ts
+++ b/src/__tests__/mocks-test.ts
@@ -1,4 +1,4 @@
-import { discoverMocks } from "../mocks";
+import { discoverMocks, getMockForJSON } from "../mocks";
 import { sync } from "glob";
 import { resolve } from "path";
 
@@ -65,6 +65,43 @@ describe("mocks", () => {
       const mockfilename = "1-valid-mock-empty-array";
       sync.mockReturnValue([mockfilename]);
       resolve.mockReturnValue(mockfilename);
+      expect(() => {
+        discoverMocks(mockfilename);
+      }).not.toThrow();
+    });
+  });
+
+  describe("#getMockForJSON", () => {
+    it("throws unless json is provided", () => {
+      expect(() => {
+        getMockForJSON(null);
+      }).toThrow();
+    });
+
+    it("throws unless valid json string is provided", () => {
+      expect(() => {
+        getMockForJSON("foo");
+      }).toThrow();
+    });
+
+    it("doesn't throw when json is provided", () => {
+      expect(() => {
+        getMockForJSON({});
+      }).not.toThrow();
+    });
+
+    it("doesn't throw when valid json string is provided", () => {
+      expect(() => {
+        getMockForJSON("{}");
+      }).not.toThrow();
+    });
+
+    it("returns doesn't throw when json is provided", () => {
+      const mockfilename = "1-valid-json-mock";
+
+      sync.mockReturnValue([mockfilename]);
+      resolve.mockReturnValue(mockfilename);
+
       expect(() => {
         discoverMocks(mockfilename);
       }).not.toThrow();

--- a/src/__tests__/server-test.ts
+++ b/src/__tests__/server-test.ts
@@ -1,5 +1,4 @@
 import express from "express";
-import { createProxyServer } from "http-proxy";
 import server from "../server";
 
 const mockExpressApp = express();

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -1,6 +1,7 @@
 import { resolve } from "path";
 import { sync as syncGlob } from "glob";
 import { IMock } from "./types";
+import { Request, RequestHandler, Response } from "express";
 
 function validateMock(file: string, mocks: any): IMock[] {
   if (!(mocks instanceof Array)) {
@@ -27,6 +28,21 @@ export const mocks = [];`);
   });
 
   return mocks as IMock[];
+}
+
+export function getMockForJSON(json: string | {}): RequestHandler {
+  if (!json) {
+    throw new Error("JSON argument is missing!");
+  }
+
+  const jsonString = JSON.stringify(
+    typeof json === "string" ? JSON.parse(json) : json
+  );
+
+  return (_req: Request, res: Response) => {
+    res.setHeader("Content-Type", "Application/json");
+    res.send(jsonString);
+  };
 }
 
 export function discoverMocks(globString: string): IMock[] {

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,8 @@ import { createProxyServer } from "http-proxy";
 import { IServerConfig } from "./types";
 import { AddressInfo } from "net";
 
+export { getMockForJSON } from "./mocks";
+
 export interface IServerHandle {
   close: () => Promise<void>;
   port: number;


### PR DESCRIPTION
With `getMockFromJSON` you can turn any JSON to a mock as easy as

```js
{
  id: "my-json-mock",
  request: getMockForJSON({value: 42})
}
```

it will stringify JavaScript Object for you and set "Content-Type: Application/json" header.

Closes DCOS-34530