### PR TITLE
chore(deps): update node:9.11.1-slim docker digest to aec2d7 - autoclosed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9.11.1-slim@sha256:8af8ba19dc651ed8b263efa2ea41af964d08e85b342eb7b7f98aa88fcbb674b7
+FROM node:9.11.1-slim@sha256:aec2d754ceb952d440079d5c2436e8bae8697ea374cb54fc44aed43e078ea1c1
 
 EXPOSE 3000
 


### PR DESCRIPTION
<p>This Pull Request updates Docker base image <code>node:9.11.1-slim</code> to the latest digest (<code>sha256:aec2d754ceb952d440079d5c2436e8bae8697ea374cb54fc44aed43e078ea1c1</code>). For details on Renovate's Docker support, please visit <a href="https://renovatebot.com/docs/docker">https://renovatebot.com/docs/docker</a></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>