### PR TITLE
chore: Allow semantic release to publish as public

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,11 +36,10 @@
   "bugs": {
     "url": "https://github.com/mesosphere/mockserver/issues"
   },
-  "standard-version": {
-    "scripts": {
-      "postchangelog": "npm run format"
-    }
+  "publishConfig": {
+    "access": "public"
   },
+  "files": ["dist"],
   "jest": {
     "collectCoverage": true,
     "coverageReporters": [


### PR DESCRIPTION
### Overview

The default when publishing to an org is private, which I guess the mesosphere org has not signed up for. This may allow publishing to proceed.

Also removes unneeded standard-version package config that I didn't notice before.